### PR TITLE
Node 0.5 is no longer provided on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - 0.4
-  - 0.5
   - 0.6
+  - 0.7
 branches:
   only:
     - master


### PR DESCRIPTION
I added 0.7 which will eventually become 0.8.0. It is a development version so it may have issues.
For an up-to-date list of runtimes and other software, please consult with our [CI Environment page](http://about.travis-ci.org/docs/user/ci-environment/)
