### PR TITLE
Installation command fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ that makes use of all available tags.
 Codo is available in NPM and can be installed with:
 
 ```bash
-$ npm install codo
+$ npm install -g codo
 ```
 
 ## Tags


### PR DESCRIPTION
Codo should be installed with `-g` key to force global installation since it's probably not supposed to work as a library.
