### PR TITLE
Spelling typo Method::getParamaters -> Method::getParameters

### DIFF
--- a/src/nodes/method.coffee
+++ b/src/nodes/method.coffee
@@ -112,7 +112,7 @@ module.exports = class Method
   #
   # @param [Array<Parameter>] the method parameters
   #
-  getParamaters: -> @parameters
+  getParameters: -> @parameters
 
   # Get the method source in CoffeeScript
   #


### PR DESCRIPTION
getParamaters should be getParmeters
