### PR TITLE
Made todo tag case insensitive

### DIFF
--- a/lib/nodes/doc.js
+++ b/lib/nodes/doc.js
@@ -65,7 +65,7 @@
             } else if (note = /^@note\s+(.*)/.exec(line)) {
               this.notes || (this.notes = []);
               this.notes.push(note[1]);
-            } else if (todo = /^@todo\s+(.*)/.exec(line)) {
+            } else if (todo = /^@todo\s+(.*)/i.exec(line)) {
               this.todos || (this.todos = []);
               this.todos.push(todo[1]);
             } else if (example = /^@example\s+(.*)/.exec(line)) {

--- a/src/nodes/doc.coffee
+++ b/src/nodes/doc.coffee
@@ -73,7 +73,7 @@ module.exports = class Doc
             @notes or= []
             @notes.push note[1]
 
-          else if todo = /^@todo\s+(.*)/.exec line
+          else if todo = /^@todo\s+(.*)/i.exec line
             @todos or= []
             @todos.push todo[1]
 


### PR DESCRIPTION
The todo tag was case sensitive which does not play well with
editors that only support word highlighting for TODO in uppercase
