### PR TITLE
Fix to allow virtual methods without parameters

### DIFF
--- a/lib/nodes/virtual_method.js
+++ b/lib/nodes/virtual_method.js
@@ -118,7 +118,7 @@
     };
 
     VirtualMethod.prototype.getParameters = function() {
-      return this.doc.params;
+      return this.doc.params || [];
     };
 
     VirtualMethod.prototype.getCoffeeScriptSource = function() {};

--- a/src/nodes/virtual_method.coffee
+++ b/src/nodes/virtual_method.coffee
@@ -114,7 +114,7 @@ module.exports = class VirtualMethod extends Node
   #
   # @param [Array<Parameter>] the method parameters
   #
-  getParameters: -> @doc.params
+  getParameters: -> @doc.params or []
 
   # Get the method source in CoffeeScript
   #


### PR DESCRIPTION
Was getting `Get method signature error: undefined [TypeError: Cannot read property 'length' of undefined]` when using `@method` to declare a method without parameters. This fixes it by making `getParameters` return an empty array in that case.

I came across this when trying to figure out a way to document my own type of 'mixin' that is returned by an instance method, e.g.

``` coffee
class Com.Example.Aspect
  mixins: =>
    # Does something interesting.
    aMixedInMethod: =>
      @somePrivateMethod()

  # @private
  somePrivateMethod: () =>
    # do something.
```

The documentation for the methods in `mixins` is ignored. I'd tried using a `@mixin` tag, but that didn't help, so I ended up going with:

``` coffee
# @method #aMixedInMethod
#   Does something interesting.
class Com.Example.Aspect
  mixins: =>
    aMixedInMethod: =>
      @somePrivateMethod()

  # @private
  somePrivateMethod: () =>
    # do something.
```

I'd rather find some way of having the doc tags alongside the method if at all possible, if you have any ideas?
