### PR TITLE
Mark the document as UTF-8.

### DIFF
--- a/theme/default/templates/partials/head.hamlc
+++ b/theme/default/templates/partials/head.hamlc
@@ -1,4 +1,5 @@
 %head
+  %meta{ charset: 'UTF-8' }
   %title= @title
   %link{ rel: 'stylesheet', href: "#{ @path }assets/codo.css", type: 'text/css' }
   %script{ src: "#{ @path }assets/codo.js" }


### PR DESCRIPTION
Adds a &lt;meta charset='UTF-8'&gt; to the head partial so you can use UTF-8 characters in your class documentation and have them displayed correctly in all browsers…
