### PR TITLE
Overloads returnValue default to method's if not set

### DIFF
--- a/theme/default/templates/partials/doc.hamlc
+++ b/theme/default/templates/partials/doc.hamlc
@@ -131,5 +131,5 @@
       - for overload in @doc.overloads
         .overload
           %p.signature
-            != "#{ if @method.type is 'instance' then '-' else '+' } (#{ if overload.returnValue then @str.escapeHTML(overload.returnValue.type) else 'void' }) #{ overload.signature }"
+            != "#{ if @method.type is 'instance' then '-' else '+' } (#{ if overload.returnValue then @str.escapeHTML(overload.returnValue.type) else if @doc?.returnValue then @str.escapeHTML(@doc.returnValue.type) else 'void' }) #{ overload.signature }"
           != @parent.JST['partials/doc']({ doc: overload, type: 'overload', path: @parent.path, referencer: @parent.referencer })

--- a/theme/default/templates/partials/method_list.hamlc
+++ b/theme/default/templates/partials/method_list.hamlc
@@ -4,7 +4,7 @@
       %p.signature{ id: "#{ method.name }-#{ method.type }" }
         - if method.doc?.overloads
           - for overload in method.doc?.overloads
-            != "#{ if method.type is 'instance' then '-' else '+' } (#{ if overload.returnValue then @str.escapeHTML(overload.returnValue.type) else 'void' }) #{ overload.signature }"
+            != "#{ if method.type is 'instance' then '-' else '+' } (#{ if overload.returnValue then @str.escapeHTML(overload.returnValue.type) else if method.doc?.returnValue then @str.escapeHTML(method.doc.returnValue.type) else 'void' }) #{ overload.signature }"
             %br
         - else
           != method.signature


### PR DESCRIPTION
Hello,
Here is a simple shortcut to avoid having to set the `@return` statement in every `@overload` definition, as it will inherit the method's `@return`.
