### PR TITLE
Ignore command line params if codo has not been started directly

### DIFF
--- a/src/codo.coffee
+++ b/src/codo.coffee
@@ -161,7 +161,9 @@ module.exports = class Codo
 
           extra = false
 
-          args = if argv._.length isnt 0 then argv._ else codoopts._
+          # ignore params if codo has not been started directly
+          args = if argv._.length isnt 0 and /.+codo$/.test(process.argv[1]) then argv._ else codoopts._
+
 
           for arg in args
             if arg is '-'


### PR DESCRIPTION
Hi there,

I found a little glitch with Codo when starting it from within another script. If you run the parent script from the command line with params Codo will try and use those params.
This pull requests adds a simple check to see if Codo has been started directly from the command line and if so it will consider the params passed.

cheers
Simone
Huzutech ltd
