### PR TITLE
Class hierarchy not generating properly

### DIFF
--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -288,12 +288,20 @@ module.exports = class Generator
           child.children or= []
           children = child.children
 
-      # Create a new class
-      children.push
-        name: entity.getName()
-        href: "#{section}/#{ entity.getFullName().replace(/\./g, '/') }.html"
-        parent: entity.getParentClassName?()
-        namespace: entity.getNamespace()
+      # Determine if we should push OR update entries
+      entry = _.find children, (c) -> c.name is entity.getName()
+      #If there is an existing entry update it
+      if entry?
+        entry.parent = entity.getParentClassName?()
+        entry.namespace = entity.getNamespace()
+        entry.href = "#{section}/#{ entity.getFullName().replace(/\./g, '/') }.html"
+      else # Otherwise push our new entry onto the array
+        children.push
+          name: entity.getName()
+          href: "#{section}/#{ entity.getFullName().replace(/\./g, '/') }.html"
+          parent: entity.getParentClassName?()
+          namespace: entity.getNamespace()
+
 
     # Create tree structure
     for clazz in @parser.classes


### PR DESCRIPTION
During generation class names that should show up as links were showing up as black text with their linkable item right below the dropdown. This was because the system was always pushing the class on to the children array instead of updating when it already exists.
