### PR TITLE
Extract file writing logic from Template.

### DIFF
--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -3,6 +3,7 @@ path       = require 'path'
 mkdirp     = require 'mkdirp'
 _          = require 'underscore'
 
+Writer     = require './util/writer'
 Templater  = require './util/templater'
 Referencer = require './util/referencer'
 Markdown   = require './util/markdown'
@@ -18,6 +19,7 @@ module.exports = class Generator
   # @param [Object] options the options
   #
   constructor: (@parser, @options) ->
+    @writer = new Writer(@options)
     @referencer = new Referencer(@parser.classes, @parser.mixins, @options)
     @templater = new Templater(@options, @referencer, @parser)
 
@@ -31,7 +33,7 @@ module.exports = class Generator
   # @param [Function] file the optional file generation callback
   #
   generate: (file) ->
-    @templater.redirect(file) if file
+    @writer.setCallback file if file
 
     @generateIndex()
 

--- a/src/util/writer.coffee
+++ b/src/util/writer.coffee
@@ -1,0 +1,42 @@
+fs         = require 'fs'
+path       = require 'path'
+mkdirp     = require 'mkdirp'
+
+# The writer knows how to write files in the user's filesystem.
+#
+module.exports = class Writer
+  # Construct a writer
+  #
+  # @param [Object] options the options
+  #
+  constructor: (@options) ->
+    @fileCallback = null
+  
+  # Configures the writer to call a function instead of creating a file
+  #
+  # @param [Function] callback called with each file's contents and name
+  #
+  setCallback: (callback) ->
+    @fileCallback = callback
+
+  # Writes a file to the user's filesystem.
+  #
+  # @param [String] content the data to be written to the file
+  # @param [String] filename the output file name
+  #
+  output: (content, filename) ->
+    # Callback generated content
+    if @fileCallback
+      @fileCallback(filename, html)
+
+    # Write to file system
+    else
+      file = path.join @options.output, filename
+      dir  = path.dirname(file)
+      mkdirp dir, (err) ->
+        if err
+          console.error "[ERROR] Cannot create directory #{ dir }: #{ err }"
+        else
+          fs.writeFile file, html
+
+   return


### PR DESCRIPTION
I think it's a bit awkward for the Templater class to have to know how to save files to disk. This means that a Generator has to use a Templater instead of, say, outputting a bunch of JSON itself.

This change pulls out the logic that decides where and how a file is written into a separate class, Writer. The writer is created in the Generator, so the creation code can be shared by Generator subclasses (if that will happen) and so that Generators can call the writer directly to output some JSON.
