### PR TITLE
Pull out theme-related logic into a Theme class.

### DIFF
--- a/src/codo.coffee
+++ b/src/codo.coffee
@@ -7,6 +7,7 @@ _         = require 'underscore'
 
 Parser    = require './parser'
 Generator = require './generator'
+Theme     = require './util/theme'
 
 # Codo - the CoffeeScript API documentation generator
 #
@@ -209,7 +210,7 @@ module.exports = class Codo
                     throw error if options.debug
                     console.log "Cannot parse file #{ filename }: #{ error.message }"
 
-          new Generator(parser, options).generate(file)
+          new Generator(parser, Codo.theme(), options).generate(file)
           parser.showResult() unless options.quiet
           done() if done
 
@@ -223,14 +224,21 @@ module.exports = class Codo
   # @return [String] the script content
   #
   @script: ->
-    @codoScript or= fs.readFileSync path.join(__dirname, '..', 'theme', 'default', 'assets', 'codo.js'), 'utf-8'
+    @theme().javaScript()
 
   # Get the Codo style content that is used in the webinterface
   #
   # @return [String] the style content
   #
   @style: ->
-    @codoStyle or= fs.readFileSync path.join(__dirname, '..', 'theme', 'default', 'assets', 'codo.css'), 'utf-8'
+    @theme().styleSheet()
+
+  # Get the current theme used to render the documentation.
+  #
+  # @return [Theme] the theme used to render the documentation
+  #
+  @theme: ->
+    @codoTheme or= new Theme path.join(__dirname, '..', 'theme', 'default')
 
   # Find the source directories.
   #

--- a/src/generator.coffee
+++ b/src/generator.coffee
@@ -15,11 +15,12 @@ module.exports = class Generator
   # Construct a generator
   #
   # @param [Parser] parser the parser
+  # @param [Theme] theme the theme
   # @param [Object] options the options
   #
-  constructor: (@parser, @options) ->
+  constructor: (@parser, @theme, @options) ->
     @referencer = new Referencer(@parser.classes, @parser.mixins, @options)
-    @templater = new Templater(@options, @referencer, @parser)
+    @templater = new Templater(@options, @referencer, @parser, @theme)
 
   # Generate the documentation. Without callback, the documentation
   # is written to the file system, with callback, the file content
@@ -384,8 +385,8 @@ module.exports = class Generator
   # Copy the styles and scripts.
   #
   copyAssets: ->
-    @copy path.join(__dirname, '..', 'theme', 'default', 'assets', 'codo.css'), path.join(@options.output, 'assets', 'codo.css')
-    @copy path.join(__dirname, '..', 'theme', 'default', 'assets', 'codo.js'), path.join(@options.output, 'assets', 'codo.js')
+    for asset in @theme.assets()
+      @copy path.join(@theme.assetPath, asset), path.join(@options.output, 'assets', asset)
 
   # Copy a file
   #

--- a/src/util/theme.coffee
+++ b/src/util/theme.coffee
@@ -1,0 +1,114 @@
+fs         = require 'fs'
+path       = require 'path'
+walkdir    = require 'walkdir'
+
+# The theme knows where all the templates and assets are.
+#
+module.exports = class Theme
+
+  # Construct a filesystem-based theme.
+  #
+  # @param [String] root the path to the theme's root directory
+  # @param [Object] options the options
+  #
+  constructor: (@root, @options) ->
+    @assetPath = path.join(@root, 'assets')
+    @loadTemplates()
+    @loadAssets()
+
+  # The names of the templates in this theme.
+  #
+  # @return [Array<String>] the names of the templates
+  #
+  templates: ->
+    @templateNames
+
+  # The uncompiled source code for a template.
+  #
+  # @param [String] template the name of the template
+  # @return [String] the template's uncompiled code
+  #
+  templateSource: (template) ->
+    @sources[template]
+
+  # The type (file extension) for a template.
+  #
+  # @param [String] template the name of the template
+  # @return [String] the template's type (e.g. "hamlc")
+  #
+  templateType: (template) ->
+    @types[template]
+
+  # The names of the assets in this theme.
+  #
+  # @return [Array<String>] the names of the assets
+  #
+  assets: ->
+    @assetNames
+
+  # The contents of the JavaScript used in this theme.
+  #
+  # @return [String] contents of the codo.js JavaScript file
+  #
+  javaScript: ->
+    @assetSources['codo.js']
+
+  # The contents of the CSS stylesheet used in this theme.
+  #
+  # @return [String] contents of the codo.css stylesheet
+  #
+  styleSheet: ->
+    @assetSources['codo.css']
+
+  # @property [String] the path to the theme's directory of static assets
+  assetPath: null
+
+  # Caches the templates in this theme.
+  #
+  # @private
+  #
+  loadTemplates: ->
+    @sources = {}
+    @types = {}
+    @templateNames = []
+
+    templatesPath = path.join(@root, 'templates')
+    for filePath in walkdir.sync(templatesPath)
+      continue unless @isThemeFile(filePath)
+      fileName = path.basename(filePath)
+      templatePath = path.relative(templatesPath, filePath)
+      console.log templatePath
+      if templatePath.lastIndexOf('.') isnt -1
+        template = templatePath.substring 0, templatePath.lastIndexOf('.')
+      else
+        template = templatePath
+      @templateNames.push(template)
+      nameSegments = fileName.split('.')
+      @types[template] = nameSegments[nameSegments.length - 1]
+      @sources[template] = fs.readFileSync(filePath, 'utf-8')
+    return
+
+  # Caches the static assets in this theme.
+  #
+  # @private
+  #
+  loadAssets: ->
+    @assetSources = {}
+    @assetNames = []
+    for filePath in walkdir.sync(@assetPath)
+      continue unless @isThemeFile(filePath)
+      asset = path.relative(@assetPath, filePath)
+      @assetNames.push(asset)
+      @assetSources[asset] = fs.readFileSync(filePath, 'utf-8')
+    return
+
+  # Checks if a path represents a file that is part of the theme.
+  #
+  # @param [String] path the path to be checked
+  # @return [Boolean] true if the path points to a theme file
+  #
+  isThemeFile: (filePath) ->
+    return false if path.basename(filePath)[0] == '.'
+    return false if fs.statSync(filePath).isDirectory()
+
+    true


### PR DESCRIPTION
The code that knows where the theme's files are is currently scattered across a few files. This change puts it all in its own class, which is (creatively) named Theme.

This change is a precursor to supporting multiple themes. Also, the simplified Templater code means it will be easier to support other templating languages, as hamlc isn't very suitable for generating JSON :)
