### PR TITLE
Issue 130

### DIFF
--- a/src/codo.coffee
+++ b/src/codo.coffee
@@ -160,7 +160,6 @@ module.exports = class Codo
           .default('title', codoopts.title || 'CoffeeScript API Documentation')
 
         argv = optimist.argv
-        console.log argv
 
         if argv.h
           console.log optimist.help()


### PR DESCRIPTION
Add a `-x` and `--extension` command-line flag to accommodate other dialects of CoffeeScript.
