### PR TITLE
Make require('codo') work in a vanilla node environment.

### DIFF
--- a/bin/codo
+++ b/bin/codo
@@ -1,4 +1,3 @@
 #!/usr/bin/env node
 
-require('coffee-script');
-require('./../src/codo').run();
+require('./../lib/index.js').run();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,4 @@
+// The codo source requires the CoffeeScript compiler and is in src/.
+
+require('coffee-script');
+module.exports = require('./../src/codo');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "theme/default/assets" : "./theme/default/assets",
     "theme/default/templates" : "./theme/default/templates"
   },
-  "main" : "./src/codo",
+  "main" : "./lib/index.js",
   "bin" : {
     "codo" : "./bin/codo"
   },


### PR DESCRIPTION
The "main" file in the package is a CoffeeScript file, so `require("codo")` fails in a vanilla node.js environment.

This change adds a "loader" file, `index.js`, which loads CoffeeScript first, and then loads src/codo.
