### PR TITLE
Fix regex for the file extensions

### DIFF
--- a/lib/codo.coffee
+++ b/lib/codo.coffee
@@ -46,7 +46,7 @@ module.exports = Codo =
     for input in (options.inputs || [path])
       if FS.existsSync(input)
         if FS.lstatSync(input).isDirectory()
-          for filename in walkdir.sync(input) when filename.match("\\._?#{options.extension}")
+          for filename in walkdir.sync(input) when filename.match("\\._?#{options.extension}$")
             environment.readCoffee(filename)
         else
           environment.readCoffee(Path.resolve input)


### PR DESCRIPTION
A dollar sign was forgotten to include. It cause an error when the target directory contains invalid matched files such as Vim swap files (ex. `.filename.coffee.swp`).
