### PR TITLE
Fixed swapped getter/setter property detection.

### DIFF
--- a/lib/entities/property.coffee
+++ b/lib/entities/property.coffee
@@ -45,8 +45,8 @@ module.exports = class Entities.Property extends require('../entity')
           @setter = false
           @getter = false
           for property in @node.args[1].base?.properties
-            @setter = true if property.variable.base.value == 'get'
-            @getter = true if property.variable.base.value == 'set'
+            @setter = true if property.variable.base.value == 'set'
+            @getter = true if property.variable.base.value == 'get'
         else
           # @property 'test', ->
           @setter = false


### PR DESCRIPTION
The conditionals determining the presence of getters/setters were backwards as identified in issue https://github.com/coffeedoc/codo/issues/158#issuecomment-43018395. This commit swaps them.
