### PR TITLE
Support multiple source extensions e.g. *.coffee and *.iced

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ Usage: codo [options] [source_files [- extra_files]]
 Options:
   --help, -h          Show this help                          
   --version           Show version                            
-  --extension, -x     Coffee files extension                    [default: "coffee"]
+  --extension, -x     Coffee files extension(s)                 [default: "coffee"]
   --output, -o        The output directory                      [default: "./doc"]
   --theme             The theme to be used                      [default: "default"]
   --name, -n          The project name used                   
@@ -600,6 +600,8 @@ CHANGELOG.md
 ```
 
 Put each option flag on a separate line, followed by the source directories or files, and optionally any extra file that should be included into the documentation separated by a dash (`-`). If your extra file has the extension `.md`, it'll be rendered as Markdown.
+
+You may specify multiple source extensions by separating them with a comma.
 
 ## Keyboard navigation
 

--- a/lib/codo.coffee
+++ b/lib/codo.coffee
@@ -35,6 +35,9 @@ module.exports = Codo =
     options.basedir   ||= path
     options.extension ||= 'coffee'
 
+    # Check if there are multiple comma-seperated extensions
+    options.extension = options.extension.replace(/\s*,\s*/, '|')
+
     environment = new @Environment(options)
 
     if environment.options.readme

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -8,7 +8,7 @@ module.exports = class Command
   options: [
     {name: 'help', alias: 'h', describe: 'Show this help'}
     {name: 'version', describe: 'Show version'}
-    {name: 'extension', alias: 'x', describe: 'Coffee files extension', default: 'coffee'}
+    {name: 'extension', alias: 'x', describe: 'Coffee files extension(s)', default: 'coffee'}
     {name: 'output', alias: 'o', describe: 'The output directory', default: './doc'}
     {name: 'output-dir'}
     {name: 'theme', describe: 'The theme to be used', default: 'default'}

--- a/spec/_templates/example/src/penguin.iced
+++ b/spec/_templates/example/src/penguin.iced
@@ -1,0 +1,26 @@
+# A iced penguin.
+#
+# @author Iced
+# @see http://en.wikipedia.org/wiki/Penguin
+# @include Example.AngryAnimal
+# @extend MissingMixin
+#
+class Example.Animal.Penguin extends Example.Animal
+
+  # Maximum speed in MPH
+  @MAX_SPEED = 100
+
+  # Move the penguin fast
+  #
+  # @param [String] direction the moving direction
+  # @param [Number] speed the moving speed
+  #
+  move: (direction, speed) ->
+    super({ diection: direction, speed: speed })
+
+  # Escape at maximum speed.
+  #
+  # @param (see #move)
+  #
+  escape: (direction) ->
+    @move(direction, @MAX_SPEED)

--- a/spec/lib/codo_spec.coffee
+++ b/spec/lib/codo_spec.coffee
@@ -4,14 +4,15 @@ Codo = require '../../lib/codo'
 describe 'Codo', ->
 
   it 'parses project', ->
-    environment = Codo.parseProject(Path.join __dirname, '../_templates/example')
-    
+    environment = Codo.parseProject(Path.join(__dirname, '../_templates/example'), { extension: 'coffee,iced' })
+
     expect(environment.allFiles().map (file) -> file.inspect().file).toEqual [
       'src/angry_animal.coffee',
       'src/animal.coffee',
       'src/lion.coffee',
       'src/over_documented_class.coffee',
-      'src/over_documented_mixin.coffee'
+      'src/over_documented_mixin.coffee',
+      'src/penguin.iced'
     ]
 
     expect(environment.allExtras().map (e) -> e.name).toEqual [


### PR DESCRIPTION
Usage: `--extension coffee,iced`

Some projects, for reasons beyond the developers control, may contain multiple coffee file extensions, e.g. coffee & iced-coffee. Specifying multiple extensions will allow parsing of both types of files.

The default of `coffee` has not been changed.

Since explicit CLI tests do not exist we test this new feature via `spec/lib/codo_spec.coffee`.