### PR TITLE
Support GHM relative linking

### DIFF
--- a/lib/tools/markdown.coffee
+++ b/lib/tools/markdown.coffee
@@ -30,6 +30,9 @@ module.exports = class Tools.Markdown
     # Remove newlines around open and closing paragraph tags
     html = html.replace /(?:\n+)?<(\/?p)>(?:\n+)?/mg, '<$1>'
 
+    # Add '.html' to relative markdown links
+    html = html.replace /href="(?!https?:\/\/)(.*\.md)"/mg, 'href="$1.html"'
+
     html
 
   # Strips all unwanted tag from the html

--- a/spec/_templates/extras/README.md
+++ b/spec/_templates/extras/README.md
@@ -9,3 +9,5 @@ And even more content
 ### Actually...
 
 I feel terribly sick writing this. It's like talking to myself.
+
+[With relative markdown links too](SomeOtherFile.md)

--- a/spec/lib/environment_spec.coffee
+++ b/spec/lib/environment_spec.coffee
@@ -41,6 +41,7 @@ describe 'Environment', ->
       expect(@environment.allExtras().map (e) -> e.inspect()).toEqual([{
         path: 'spec/_templates/extras/README.md',
         parsed: '<h1 id="this-is-a-test-readme">This is a test README</h1><p>We even have some content here. <a href="http://github.com">With links!</a></p><h2 id="and-nested-menus">And nested menus</h2><p>And even more content</p><h3 id="actually-">Actually...</h3><p>I feel terribly sick writing this. It&#39;s like talking to myself.</p>'
+        parsed: '<h1 id="this-is-a-test-readme">This is a test README</h1><p>We even have some content here. <a href="http://github.com">With links!</a></p><h2 id="and-nested-menus">And nested menus</h2><p>And even more content</p><h3 id="actually-">Actually...</h3><p>I feel terribly sick writing this. It&#39;s like talking to myself.</p><p><a href="SomeOtherFile.md.html">With relative markdown links too</a></p>'
       }])
 
   describe 'Class', ->


### PR DESCRIPTION
Github is capable of relative links in READMEs. We support this style
of linking for generated documentation as well.

We post-process the markdown for relative links to other markdown,
adding the necessary ‘.html’.

A unit test has been modified to check for correct behavior.

[1] https://help.github.com/articles/relative-links-in-readmes