### PR TITLE
Fixed path splitting under Windows

### DIFF
--- a/themes/default/lib/theme.coffee
+++ b/themes/default/lib/theme.coffee
@@ -102,7 +102,7 @@ module.exports = class Theme.Theme
 
   calculatePath: (filename) ->
     dirname = Path.dirname(filename)
-    dirname.split('/').map(-> '..').join('/')+'/' unless dirname == '.'
+    dirname.split(/[\/\\]/).map(-> '..').join('/')+'/' unless dirname == '.'
 
   render: (source, destination, context={}) ->
     globalContext =


### PR DESCRIPTION
Under Windows the `dirname` in `Theme.calulatePath` will cointain both `/` and `\` as path separators. For example `file/lib\api\test\asdf\index.coffee.html` and thus all asset files were looked from a wrong folder.