### PR TITLE
Fix block comments conversion

### DIFF
--- a/lib/traverser.coffee
+++ b/lib/traverser.coffee
@@ -62,7 +62,10 @@ module.exports = class Traverser
       blockComment = /^\s*#{3}/.exec(line) && !/^\s*#{3}.+#{3}/.exec(line)
 
       if blockComment || inBlockComment
-        line = line.replace /#{3}\*/, "###" if closure
+        if closure
+          line = line
+            .replace /#{3}\*/, "###"
+            .replace /\s{2}\*/, ""
         inBlockComment = !inBlockComment if blockComment
         result.push line
       else


### PR DESCRIPTION
Sublime Text 3 coffee syntax highlighting and Docblockr plugin works well with comments, such as:
```coffee
  ###*
   * [reactify description]
   * @param  {[type]} type [description]
   * @return {[type]}      [description]
  ###
  @reactify = (type) ->
    component = _specs[type.name] ?= React.createClass(
     ...
```
But codo doesn't support it! Fix it with merge, please. *Thanks for codo!*