### PR TITLE
Fix reference error caused by mistype

### DIFF
--- a/lib/entities/method.coffee
+++ b/lib/entities/method.coffee
@@ -7,7 +7,7 @@ module.exports = class Entities.Method extends require('../entity')
     node.constructor.name == 'Assign' && node.value?.constructor.name == 'Code'
 
   constructor: (@environment, @file, @node) ->
-    @name = [node.variable.base.value]
+    @name = [@node.variable.base.value]
     @name.push prop.name.value for prop in @node.variable.properties when prop.name?
 
     if @name[0] == 'this'


### PR DESCRIPTION
I keep getting this kind of error while running codo

e.g   `codo method.coffee` 

>  error: Cannot parse Coffee file /Users/hikerpig/.nvm/v0.10.33/lib/node_modules/codo/lib/entities/method.coffee: node is not defined

And this is how I fix it, at least make codo possible to run.