### PR TITLE
Add @namespace for manual namespacing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ The following table shows the list of all available tags in alphabetical order w
   </thead>
   <tbody>
     <tr>
+      <td><strong>@namespace</strong> namespace</td>
+      <td></td>
+      <td>&#10004;</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
       <td><strong>@abstract</strong> (message)</td>
       <td></td>
       <td>&#10004;</td>

--- a/lib/documentation.coffee
+++ b/lib/documentation.coffee
@@ -113,6 +113,9 @@ module.exports = class Documentation
             title: title
             code: code.join '\n'
 
+      else if namespace = /^@namespace\s+(.+)/i.exec line
+        @namespace = namespace[1] || ''
+
       else if abstract = /^@abstract(?:\s+(.+))?/i.exec line
         @abstract = abstract[1] || ''
 
@@ -209,6 +212,7 @@ module.exports = class Documentation
       notes: @notes
       see: @see
 
+      namespace: @namespace
       abstract: @abstract
       private: @private
       deprecated: @deprecated

--- a/lib/entities/class.coffee
+++ b/lib/entities/class.coffee
@@ -29,7 +29,7 @@ module.exports = class Entities.Class extends require('../entity')
 
     name = @name.split('.')
     @basename  = name.pop()
-    @namespace = name.join('.')
+    @namespace = @documentation?.namespace or name.join('.')
 
     if @environment.options.debug
       Winston.info "Creating new Class Entity"

--- a/spec/_templates/classes/namespaced_class.coffee
+++ b/spec/_templates/classes/namespaced_class.coffee
@@ -3,3 +3,7 @@ class Some.Namespace.MyClass
 
 # Test description
 class @Another.Namespace.MyClass
+
+# Test description
+# @namespace Manual.Namespace
+class MyClass

--- a/spec/_templates/classes/namespaced_class.json
+++ b/spec/_templates/classes/namespaced_class.json
@@ -32,5 +32,20 @@
     "includes": [],
     "extends": [],
     "concerns": []
+  },
+  {
+    "file": "spec/_templates/classes/namespaced_class.coffee",
+    "documentation": {
+      "comment": "Test description",
+      "summary": "Test description",
+      "namespace": "Manual.Namespace"
+    },
+    "name": "MyClass",
+    "methods": [],
+    "variables": [],
+    "properties": [],
+    "includes": [],
+    "extends": [],
+    "concerns": []
   }
 ]


### PR DESCRIPTION
Hello,

I'd like to add an extra tag that would allow people to override the automatic namespace detection. I normally use folder hierarchy to namespace my projects but would still like to have the namespace hierarchy view in the generated documents.

```coffeescript
# inside storage/entities
#
# @namespace Storage.Entities
#
class SomeClass
```

There is also an issue in this PR that needs to be addressed. If the namespace is overridden, should the class name appear as the basename + classname as it does before the parsing, or should the basename be trimmed off as it is now?

Thank you for your time and this kick ass tool.

*fixed spelling.*