### PR TITLE
Output colored diff to spot test failure for properties.coffee/json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "strftime": "~0.6.2"
   },
   "devDependencies": {
+    "diff": ">=2.1.1",
     "jasmine-node": ">= 1.13.1",
     "rimraf": "~2.2.2",
     "grunt": "~0.4.1",


### PR DESCRIPTION
The `spec/lib/environment_spec.coffee` test fails, because the documentation for a method is not produced as expected. This patch makes this more visible.

It does not fix the failure though.