### PR TITLE
Add @namespace support for @mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following table shows the list of all available tags in alphabetical order w
       <td><strong>@namespace</strong> namespace</td>
       <td></td>
       <td>&#10004;</td>
-      <td></td>
+      <td>&#10004;</td>
       <td></td>
     </tr>
     <tr>

--- a/lib/entities/mixin.coffee
+++ b/lib/entities/mixin.coffee
@@ -42,7 +42,7 @@ module.exports = class Entities.Mixin extends Entity
 
     name = @name.split('.')
     @basename  = name.pop()
-    @namespace = name.join('.')
+    @namespace = @documentation?.namespace or name.join('.')
     if @environment.options.debug
       Winston.info "Creating new Mixin Entity"
       Winston.info " name: " + @name

--- a/spec/_templates/mixins/mixin_documentation.coffee
+++ b/spec/_templates/mixins/mixin_documentation.coffee
@@ -20,6 +20,7 @@
 # @since 1.0.0
 # @version 1.0.2
 #
+# @namespace Manual.Namespace
 # @mixin
 #
 Foo.Bar = {}

--- a/spec/_templates/mixins/mixin_documentation.json
+++ b/spec/_templates/mixins/mixin_documentation.json
@@ -32,7 +32,8 @@
           "title": "Use it in this way",
           "code": "class Rumba\n  @include Foo.Bar"
         }
-      ]
+      ],
+      "namespace": "Manual.Namespace"
     },
     "methods": [],
     "variables": []


### PR DESCRIPTION
Currently, the mixin directory structure is derived from the name and ignore the `@namespace` tag entirely. This patch honors the the tag and puts the mixin html file in the correct directory.