### PR TITLE
Fix limited MD rendering

### DIFF
--- a/lib/tools/markdown.coffee
+++ b/lib/tools/markdown.coffee
@@ -44,5 +44,12 @@ module.exports = class Tools.Markdown
   @limit: (html, allowed) ->
     allowed = allowed.split ','
 
-    html.replace /<([a-z]+)>(.+?)<\/\1>/, (match, tag, text) ->
-      if allowed.indexOf(tag) is -1 then text else match
+    replace = (html) ->
+      result = html.replace /<([a-z0-9]+)\s*(?:\s[^>]+)?>([\s\S]+?)<\/\1>/g, (match, tag, text) ->
+        if allowed.indexOf(tag) is -1 then text else match
+      if result == html
+        result
+      else
+        replace(result)
+    replace(html)
+

--- a/spec/lib/tools/markdown_spec.coffee
+++ b/spec/lib/tools/markdown_spec.coffee
@@ -1,0 +1,23 @@
+Markdown = require '../../../lib/tools/markdown'
+jsdiff      = require 'diff'
+
+describe 'Markdown', ->
+  describe 'limited markdown conversion', ->
+    limit = true
+
+    it 'removes non-inline tags', ->
+      markdown = """
+      # A markdown list
+      - THING_1
+      - THING_2 - A long, mulitline
+        list element
+      """
+
+      expect(Markdown.convert(markdown, limit)).toEqual("""
+      A markdown list 
+      THING_1
+      THING_2 - A long, mulitline
+      list element
+
+
+      """)


### PR DESCRIPTION
This fixes a few issues with the current solution, all of which are
covered by the accompanied test:
 - Fixes matching tags whose contents span multiple lines. This is
   accomplished with the change from `(.+?)` to `([\s\S]+?)`.
 - Fixes matching tags such as `<h1>` with the change from `[a-z]` to
   `[a-z0-9]`.
 - Fixes matching tags with attributes, such as `<h1 id="title">` by
   adding `\s*(?:\s[^>]+)?` after the tag name matcher.
 - Fixes matching more than one tag by adding the `g` flag.
 - Fixes matching nested tags by recursively calling the replace
   function until it stops having any further effect. Note that this
   renders the `g` flag redundant, but I left the flag in, because it
   avoids the recursive call stack getting unnecessarily deep.

The test could probably be improved to not have to require the one
trailing whitespace in and the empty newlines at the end of the expected
string, but I couldn't think of a good way to do this right away.