### PR TITLE
Avoid reversing text order in @property comment

### DIFF
--- a/lib/documentation.coffee
+++ b/lib/documentation.coffee
@@ -23,7 +23,7 @@ module.exports = class Documentation
 
       if property = /^@property\s+[\[\{](.+?)[\]\}](?:\s+(.+))?/i.exec line
         @property = property[1]
-        lines.push property[2]
+        lines.unshift property[2]
 
       else if returns = /^@return\s+[\[\{](.+?)[\]\}](?:\s+(.+))?/i.exec line
         @returns =

--- a/spec/_templates/properties/properties.coffee
+++ b/spec/_templates/properties/properties.coffee
@@ -3,7 +3,9 @@
 #
 module.exports = class Person
 
-  # @property [Array<String>] the nicknames
+  # @property [Array<String>] The nicknames
+  #
+  # All the nicknames the person is known by.
   nicknames: []
 
   # @property [Object] The entity's position

--- a/spec/_templates/properties/properties.json
+++ b/spec/_templates/properties/properties.json
@@ -32,8 +32,8 @@
         "getter": true,
         "setter": true,
         "documentation": {
-          "comment": "the nicknames",
-          "summary": "the nicknames",
+          "comment": "The nicknames\n\nAll the nicknames the person is known by.",
+          "summary": "The nicknames\n\nAll the nicknames the person is known by.",
           "property": "Array<String>"
         }
       },
@@ -155,8 +155,8 @@
     "getter": true,
     "setter": true,
     "documentation": {
-      "comment": "the nicknames",
-      "summary": "the nicknames",
+      "comment": "The nicknames\n\nAll the nicknames the person is known by.",
+      "summary": "The nicknames\n\nAll the nicknames the person is known by.",
       "property": "Array<String>"
     }
   },


### PR DESCRIPTION
As mentioned in #227, this will remove the limited markdown restriction from *property* documentation.