### PR TITLE
Resolve https://github.com/coffeedoc/codo/issues/204

### DIFF
--- a/lib/documentation.coffee
+++ b/lib/documentation.coffee
@@ -47,6 +47,20 @@ module.exports = class Documentation
           type: '?'
           description: throws[1]
 
+      else if param = /^@param\s+[\[\{](.+?)[\]}]\s+\[([^\]]+)](?:\s+(.+))?/i.exec line
+        if paramNameVal = /^([^ ]+)\s*=\s*([^ ]+)/.exec param[2]
+          paramName = paramNameVal[1]
+          defValue = paramNameVal[2]
+        else
+          defValue = null
+          paramName = param[2]
+        @params.push
+          type: param[1]
+          name: paramName
+          description: param[3]
+          defaultState: defValue
+          optional: yes
+
       else if param = /^@param\s+([^ ]+)\s+[\[\{](.+?)[\]\}](?:\s+(.+))?/i.exec line
         @params ?= []
         @params.push

--- a/themes/default/assets/stylesheets/class.styl
+++ b/themes/default/assets/stylesheets/class.styl
@@ -169,6 +169,10 @@
         font-family: monospace;
         font-weight: bold;
       }
+
+      .defaultState {
+        font-style: italic;
+      }
     }
 
     .overloads {

--- a/themes/default/templates/partials/documentation.hamlc
+++ b/themes/default/templates/partials/documentation.hamlc
@@ -49,11 +49,16 @@
       %ul.param
         - for param in @documentation.params
           %li
-            %span.name= param.name
+            - if param.optional
+              %span.name= '['+param.name+']'
+            - else
+              %span.name= param.name
             %span.type
               (
                 != @render('partials/type_link', type: param.type)
               )
+            - if param.defaultState
+              %span.defaultState= ' = '+param.defaultState
             - if param.description
               &mdash;
               %span.desc!= @activate param.description, @path, true


### PR DESCRIPTION
Print info about default value and optional params
Format with type before name only:
```coffeescript
# @param {String} [name] optional value
# @param {Number} [input = 1] optional with default value
# or
# @param [String] [name] optional value
# @param [Number] [input = 1] optional with default value
```