### PR TITLE
Fix empty property description hiding documentation

### DIFF
--- a/lib/documentation.coffee
+++ b/lib/documentation.coffee
@@ -23,7 +23,7 @@ module.exports = class Documentation
 
       if property = /^@property\s+[\[\{](.+?)[\]\}](?:\s+(.+))?/i.exec line
         @property = property[1]
-        lines.unshift property[2]
+        lines.unshift property[2] if property[2]?
 
       else if returns = /^@return\s+[\[\{](.+?)[\]\}](?:\s+(.+))?/i.exec line
         @returns =

--- a/spec/_templates/properties/properties.coffee
+++ b/spec/_templates/properties/properties.coffee
@@ -8,7 +8,8 @@ module.exports = class Person
   # All the nicknames the person is known by.
   nicknames: []
 
-  # @property [Object] The entity's position
+  # @property [Object]
+  # The entity's position
   position:
     x: 0
     y: 0


### PR DESCRIPTION
PR #229 introduced an issue where if the `@property`'s description wasn't
filled in, the rest of the comment body would also be left out of the
documentation. This was caused by `property[2]` being undefined and
prepended to the `lines` array which caused the while loop to terminate
early. The while loop checks if the last value shifted from the array is
`undefined` not if there are any more values left in the array.