### PR TITLE
Update marked to >= 0.3.6 and sanitize input

### DIFF
--- a/lib/tools/markdown.coffee
+++ b/lib/tools/markdown.coffee
@@ -1,6 +1,10 @@
 marked = require 'marked'
 Tools  = require '../_tools'
 
+marked.setOptions(
+  sanitize: true
+)
+
 # It looks like all the markdown libraries for node doesn't get
 # GitHub flavored markdown right. This helper class post-processes
 # the best available output from the marked library to conform to

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "coffee-script": ">= 1.6.0",
     "walkdir": ">= 0.0.2",
     "optimist": ">= 0.3.0",
-    "marked": ">= 0.2.10",
+    "marked": ">= 0.3.6",
     "underscore": ">= 0.1.0",
     "underscore.string": ">= 0.1.0",
     "haml-coffee": ">= 0.6.0",

--- a/spec/lib/tools/markdown_spec.coffee
+++ b/spec/lib/tools/markdown_spec.coffee
@@ -2,6 +2,12 @@ Markdown = require '../../../lib/tools/markdown'
 jsdiff      = require 'diff'
 
 describe 'Markdown', ->
+
+  describe 'Input sanitizing', ->
+    it "won't allow javascript:.* links", ->
+      markdown = "x[URL](javascript&#58document;alert&#40;1&#41;)x"
+      expect(Markdown.convert(markdown, true)).toEqual("xx ")
+
   describe 'limited markdown conversion', ->
     limit = true
 


### PR DESCRIPTION
This mitigates chij/marked#592
