### PR TITLE
Add @public tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ The following table shows the list of all available tags in alphabetical order w
       <td>&#10004;</td>
     </tr>
     <tr>
+      <td><strong>@public</strong></td>
+      <td></td>
+      <td>&#10004;</td>
+      <td></td>
+      <td>&#10004;</td> 
+    </tr> 
+    <tr>
       <td><strong>@return</strong> [type] description</td>
       <td></td>
       <td></td>

--- a/lib/documentation.coffee
+++ b/lib/documentation.coffee
@@ -137,6 +137,9 @@ module.exports = class Documentation
       else if /^@private/.exec line
         @private = true
 
+      else if /^@public/.exec line
+        @public = true
+      
       else if since = /^@since\s+(.+)/i.exec line
         @since = since[1] || ''
 
@@ -230,6 +233,7 @@ module.exports = class Documentation
       namespace: @namespace
       abstract: @abstract
       private: @private
+      public: @public
       deprecated: @deprecated
       version: @version
       since: @since

--- a/spec/_templates/classes/class_documentation.coffee
+++ b/spec/_templates/classes/class_documentation.coffee
@@ -21,6 +21,7 @@
 # @author Plasticman
 # @abstract Each listener implementation must inherit
 # @private
+# @public
 # @deprecated Use other class
 #   which is thread safe
 # @since 1.0.0

--- a/spec/_templates/classes/class_documentation.json
+++ b/spec/_templates/classes/class_documentation.json
@@ -15,6 +15,7 @@
       ],
       "abstract": "Each listener implementation must inherit",
       "private": true,
+      "public": true,
       "deprecated": "Use other class which is thread safe",
       "version": "1.0.2",
       "since": "1.0.0",

--- a/spec/_templates/methods/method_documentation.coffee
+++ b/spec/_templates/methods/method_documentation.coffee
@@ -2,6 +2,7 @@ class App.TestMethodDocumentation extends App.Doc
 
   # Should be overloaded to change fetch limit.
   #
+  # @public
   # @return Number of items per fetch
   #
   fetchLimit: () -> 5

--- a/spec/_templates/methods/method_documentation.json
+++ b/spec/_templates/methods/method_documentation.json
@@ -16,6 +16,7 @@
         "documentation": {
           "comment": "Should be overloaded to change fetch limit.",
           "summary": "Should be overloaded to change fetch limit.",
+          "public": true,
           "returns": {
             "type": "?",
             "description": "Number of items per fetch"
@@ -249,6 +250,7 @@
     "documentation": {
       "comment": "Should be overloaded to change fetch limit.",
       "summary": "Should be overloaded to change fetch limit.",
+      "public": true,
       "returns": {
         "type": "?",
         "description": "Number of items per fetch"

--- a/themes/default/templates/class.hamlc
+++ b/themes/default/templates/class.hamlc
@@ -18,6 +18,9 @@
         - if @entity.documentation?.private?
           %span.private.note.title Private
 
+        - if @entity.documentation?.public?
+          %span.public.note.title Public
+
       %table.box
         %tr
           %td Defined in:


### PR DESCRIPTION
Even though public is implicit by default, this gives extra flexibility to explicitly mark classes and methods as public.
